### PR TITLE
fix: update deprecated 'EnforcedStyle' rule

### DIFF
--- a/rubocop-base.yml
+++ b/rubocop-base.yml
@@ -1,7 +1,9 @@
-require:
-  - rubocop-rspec
-  - rubocop-rails
+plugins:
   - rubocop-performance
+  - rubocop-factory_bot
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-rspec_rails
 AllCops:
   Exclude:
   - "vendor/**/*"

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -262,7 +262,7 @@ RSpec/VerifiedDoubleReference:
   Description: Checks for consistent verified double reference style.
   Enabled: true
   SafeAutoCorrect: false
-  EnforcedStyle: constant
+  EnforcedReferenceStyle: constant
   SupportedStyles:
     - constant
     - string


### PR DESCRIPTION
Se actualiza regla obsoleta y se usa `plugins` en vez del `require` que está deperecado.

👉 Lo probé desde Surbtc y Patabit apuntando a esta rama y anda bien.