### PR TITLE
fix: bajar la severidad de guard clauses

### DIFF
--- a/rubocop-base.yml
+++ b/rubocop-base.yml
@@ -114,6 +114,7 @@ Style/GuardClause:
   Description: Check for conditionals that can be replaced with guard clauses
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
   Enabled: true
+  Severity: warning
   MinBodyLength: 1
 Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.


### PR DESCRIPTION
Dejamos la regla de guard clauses con severidad `warning` para cuando no bloquear meges. Hay casos en la que la regla no necesariamente mejora la legibilidad del flujo, ver [hilo](https://budacom.slack.com/archives/C05S5FJNMND/p1775766461282009?thread_ts=1775765918.879939&cid=C05S5FJNMND).