### PR TITLE
fix(layout): exempt full-line comments from LineLength

### DIFF
--- a/rubocop-base.yml
+++ b/rubocop-base.yml
@@ -458,6 +458,8 @@ Layout/LineLength:
   URISchemes:
   - http
   - https
+  AllowedPatterns:
+    - '^\s*#'
 Layout/EndAlignment:
   Description: Align ends correctly.
   Enabled: true


### PR DESCRIPTION
## Resumen
- Se agrega `AllowedPatterns` con `^\s*#` a `Layout/LineLength` para eximir líneas que son solo comentarios del límite de 100 caracteres.
- Corrige fallos de CI en comentarios de esquema generados por annotate (líneas largas de índices/FKs al final de modelos) sin overrides por repo ni `rubocop:disable` en cada archivo.

## Contexto
La salida de annotate en apps Budacom (p. ej. budacom/patabit-engine#3177) produce líneas de comentario de índices que superan `Max: 100`. Este patrón cubre cualquier línea que sea únicamente un comentario (espacios opcionales + `#`), incluyendo todo el bloque de esquema de annotate.

## Alternativas descartadas
- **Patrones específicos de annotate** (p. ej. `index_`, `fk_rails_`, `Table name:`): más frágiles ante cambios de formato y requieren mantenimiento continuo.
- **Wrappers en `auto_annotate_models.rake`** (`rubocop:disable`/`enable` alrededor del bloque): más precisos por archivo, pero exigen configuración y re-anotación en cada app; no centralizan la regla en `rubocop-config`.

## Plan de prueba
- [ ] Mergear (y publicar tag/release si aplica)
- [ ] En `patabit-engine`, refrescar config heredada y quitar override local de `Layout/LineLength` `AllowedPatterns` si existe
- [ ] Ejecutar `rubocop app/models/bid.rb app/models/ask.rb` — sin ofensas `Layout/LineLength` en comentarios de esquema
- [ ] Confirmar que líneas de código con comentario al final siguen fallando si exceden el límite (el patrón solo aplica a líneas 100% comentario)